### PR TITLE
Add and update bot functionality

### DIFF
--- a/groupme.gemspec
+++ b/groupme.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'
-  gem.add_development_dependency 'webmock'
+  gem.add_development_dependency 'webmock', '~> 1.19.0'
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'json', '~> 1.7'

--- a/lib/groupme/bots.rb
+++ b/lib/groupme/bots.rb
@@ -37,5 +37,17 @@ module GroupMe
       }
       post('/bots', data)
     end
+
+    # Remove a bot.
+    #
+    # @return [Boolean] Success/Failure
+    # @see https://dev.groupme.com/docs/v3#bots_destroy
+    # @param id [String, Integer] ID of the bot
+    def destroy_bot(id)
+      data = {
+        :bot_id => id
+      }
+      post('/bots/destroy', data).status == 200
+    end
   end
 end

--- a/lib/groupme/bots.rb
+++ b/lib/groupme/bots.rb
@@ -12,6 +12,22 @@ module GroupMe
     end
     alias_method :list_bots, :bots
 
+    # Post a message from a bot.
+    #
+    # @return [Boolean] Success/Failure
+    # @see https://dev.groupme.com/docs/v3#bots_post
+    # @param id [String, Integer] ID of the bot
+    # @param text [String] Text to send to the group
+    # @option options [String] :picture_url Picture URL from image service
+    def bot_post(id, text, options = {})
+      data = {
+        :bot_id => id,
+        :text => text
+      }
+      data[:options] = options if options.any?
+      post('/bots/post', data).status == 202
+    end
+
     # Create a new bot.
     #
     # @return [Hashie::Mash] Hash representing the bot.

--- a/lib/groupme/bots.rb
+++ b/lib/groupme/bots.rb
@@ -12,17 +12,6 @@ module GroupMe
     end
     alias_method :list_bots, :bots
 
-    # Get a single bot.
-    #
-    # @return [Hashie::Mash] Hash representing the bot.
-    # @see https://dev.groupme.com/docs/v3#bots_show
-    # @example
-    #   client = GroupMe::Client.new
-    #   client.bot(32)
-    def bot(id)
-      get("/bots/#{id}")
-    end
-
     # Create a new bot.
     #
     # @return [Hashie::Mash] Hash representing the bot.

--- a/lib/groupme/bots.rb
+++ b/lib/groupme/bots.rb
@@ -22,5 +22,20 @@ module GroupMe
     def bot(id)
       get("/bots/#{id}")
     end
+
+    # Create a new bot.
+    #
+    # @return [Hashie::Mash] Hash representing the bot.
+    # @see https://dev.groupme.com/docs/v3#bots_create
+    # @param name [String] Name for the new bot
+    # @param group_id [String, Integer] ID of the group
+    # @option options [String] :avatar_url Avatar image URL for the bot
+    # @option options [String] :callback_url Callback URL for the bot
+    def create_bot(name, group_id, options = {})
+      data = {
+        :bot => options.merge(:name => name, :group_id => group_id)
+      }
+      post('/bots', data)
+    end
   end
 end

--- a/lib/groupme/client.rb
+++ b/lib/groupme/client.rb
@@ -32,7 +32,7 @@ module GroupMe
 
     def request(method, path, data = {})
       res = connection.send(method, "v3/#{path}", data)
-      if res.success? && !res.body.empty?
+      if res.success? && !res.body.empty? && res.body != ' '
         return res.body.response
       else
         return res

--- a/spec/groupme/bots_spec.rb
+++ b/spec/groupme/bots_spec.rb
@@ -26,4 +26,20 @@ describe GroupMe::Bots do
 
   end
 
+  describe '.create_bot' do
+
+    it 'creates a new bot' do
+      data = {
+        :bot => {
+          :name => 'hal9000',
+          :group_id => 1234567890
+        }
+      }
+      stub_post('/bots', data).to_return(json_response('bot.json', 201))
+      bot = @client.create_bot('hal9000', 1234567890)
+      expect(bot.name).to eq('hal9000')
+    end
+
+  end
+
 end

--- a/spec/groupme/bots_spec.rb
+++ b/spec/groupme/bots_spec.rb
@@ -42,4 +42,17 @@ describe GroupMe::Bots do
 
   end
 
+  describe '.destroy_bot' do
+
+    it 'destroys a bot' do
+      data = {
+        :bot_id => 1234567890
+      }
+      stub_post('/bots/destroy', data).to_return(:status => 200)
+      response = @client.destroy_bot(1234567890)
+      expect(response).to eq(true)
+    end
+
+  end
+
 end

--- a/spec/groupme/bots_spec.rb
+++ b/spec/groupme/bots_spec.rb
@@ -16,6 +16,20 @@ describe GroupMe::Bots do
 
   end
 
+  describe '.bot_post' do
+
+    it 'posts a message to a group' do
+      data = {
+        :bot_id => 1234567890,
+        :text => 'Test message'
+      }
+      stub_post('/bots/post', data).to_return(:status => 202, :body => ' ')
+      response = @client.bot_post(1234567890, 'Test message')
+      expect(response).to eq(true)
+    end
+
+  end
+
   describe '.create_bot' do
 
     it 'creates a new bot' do

--- a/spec/groupme/bots_spec.rb
+++ b/spec/groupme/bots_spec.rb
@@ -16,16 +16,6 @@ describe GroupMe::Bots do
 
   end
 
-  describe '.bot' do
-
-    it 'returns the matching bot' do
-      stub_get('/bots/1234567890').to_return(json_response('bot.json'))
-      bot = @client.bot(1234567890)
-      expect(bot.name).to eq('hal9000')
-    end
-
-  end
-
   describe '.create_bot' do
 
     it 'creates a new bot' do


### PR DESCRIPTION
This adds in some more of the bot-related functionality exposed by the GroupMe API, including methods to create, delete, and post from bots. It also removes the method to get information for a single bot, since that does not appear to be supported anymore. Basically, everything that the GroupMe API supports in relation to bots is now implemented here.

For now, I am forcing an older version of webmock to be used so that all of the tests pass as they are currently written. This may not be a viable long-term solution, though. Also, I can't think right now if there's a cleaner way to handle the /bots/post response body being a space character (which is strange - I don't know why it isn't just an empty body). Without the check in client.rb, it will try to `return res.body.response` and fail.