### PR TITLE
Use random GUIDs when sending messages

### DIFF
--- a/groupme.gemspec
+++ b/groupme.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'json', '~> 1.7'
-  gem.add_development_dependency 'timecop', '~> 0.7'
   gem.add_development_dependency 'rubocop', '~> 0.33'
 
   gem.add_dependency 'faraday', '~> 0.9.0'

--- a/lib/groupme/messages.rb
+++ b/lib/groupme/messages.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module GroupMe
   module Messages
     # Create a message for a group
@@ -10,7 +12,7 @@ module GroupMe
     def create_message(group_id, text, attachments = [])
       data = {
         :message => {
-          :source_guid => Time.now.to_s,
+          :source_guid => SecureRandom.uuid,
           :text => text
         }
       }

--- a/spec/groupme/messages_spec.rb
+++ b/spec/groupme/messages_spec.rb
@@ -6,6 +6,7 @@ describe GroupMe::Messages do
 
   before do
     @client = GroupMe::Client.new(:token => 'TEST')
+    allow(SecureRandom).to receive(:uuid).and_return('GUID')
   end
 
   describe '.message_count' do
@@ -29,18 +30,10 @@ describe GroupMe::Messages do
 
   describe '.create_message' do
 
-    before do
-      Timecop.freeze(Time.new(2014, 10, 25, 22, 33, 44, 0000))
-    end
-
-    after do
-      Timecop.return
-    end
-
     it 'sends a text only message to a group' do
       message = {
         :message => {
-          :source_guid => '2014-10-25 22:33:44 +0000',
+          :source_guid => 'GUID',
           :text => 'Hello world ☃☃'
         }
       }
@@ -52,7 +45,7 @@ describe GroupMe::Messages do
     it 'sends a message with location to a group' do
       message = {
         :message => {
-          :source_guid => '2014-10-25 22:33:44 +0000',
+          :source_guid => 'GUID',
           :text => 'Hello world ☃☃',
           :attachments => [
             {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'groupme'
 require 'multi_json'
 require 'webmock/rspec'
-require 'timecop'
 
 def stub_get(url)
   stub_request(:get, "https://api.groupme.com/v3#{url}")


### PR DESCRIPTION
The use of the current timestamp as a message GUID was causing issues when I attempted to send messages within one second of each other (my particular case involved looping through a couple groups to "broadcast" a message to them). This update changes create_message to use a randomly-generated GUID (through the built-in SecureRandom module). I've also taken the liberty of removing the Timecop dependency, since it was only being used to test the time-based ID creation.