### PR TITLE
Added get_all_messages method to return a full list of messages for a group

### DIFF
--- a/lib/groupme.rb
+++ b/lib/groupme.rb
@@ -2,5 +2,5 @@ require 'groupme/version'
 require 'groupme/client'
 
 module GroupMe
-  USER_AGENT = "dwradcliffe/groupme/#{GroupMe::VERSION}"
+  USER_AGENT = "dwradcliffe/groupme/#{GroupMe::VERSION}".freeze
 end

--- a/lib/groupme/bots.rb
+++ b/lib/groupme/bots.rb
@@ -10,7 +10,7 @@ module GroupMe
     def bots
       get('/bots')
     end
-    alias_method :list_bots, :bots
+    alias list_bots bots
 
     # Post a message from a bot.
     #

--- a/lib/groupme/client.rb
+++ b/lib/groupme/client.rb
@@ -22,8 +22,8 @@ module GroupMe
 
     private
 
-    def get(path)
-      request(:get, path)
+    def get(path, options = {})
+      request(:get, path, options)
     end
 
     def post(path, data = {})

--- a/lib/groupme/client.rb
+++ b/lib/groupme/client.rb
@@ -33,9 +33,9 @@ module GroupMe
     def request(method, path, data = {})
       res = connection.send(method, "v3/#{path}", data)
       if res.success? && !res.body.empty? && res.body != ' '
-        return res.body.response
+        res.body.response
       else
-        return res
+        res
       end
     end
 

--- a/lib/groupme/groups.rb
+++ b/lib/groupme/groups.rb
@@ -10,7 +10,7 @@ module GroupMe
     def groups
       get '/groups'
     end
-    alias_method :list_groups, :groups
+    alias list_groups groups
 
     # Load a specific group.
     #
@@ -34,7 +34,7 @@ module GroupMe
     def former_groups
       get '/groups/former'
     end
-    alias_method :list_former_groups, :former_groups
+    alias list_former_groups former_groups
 
     # Create a new group.
     #
@@ -46,7 +46,7 @@ module GroupMe
     # @option options [String] :image_url GroupMe Image Service URL
     # @option options [Boolean] :share If you pass a true value, a share URL will be generated
     def create_group(name, options = {})
-      options.merge! :name => name
+      options[:name] = name
       post '/groups', options
     end
 

--- a/lib/groupme/messages.rb
+++ b/lib/groupme/messages.rb
@@ -42,7 +42,7 @@ module GroupMe
     def messages_count(group_id)
       get("/groups/#{group_id}/messages")['count']
     end
-    alias_method :message_count, :messages_count
+    alias message_count messages_count
 
     private
 

--- a/lib/groupme/messages.rb
+++ b/lib/groupme/messages.rb
@@ -25,8 +25,14 @@ module GroupMe
     # @return [Array<Hashie::Mash>] Array of hashes representing the messages
     # @see https://dev.groupme.com/docs/v3#messages_index
     # @param group_id [String, Integer] Id of the group
-    def messages(group_id)
-      get("/groups/#{group_id}/messages").messages
+    # @param options [Hash] options hash that will be passed to the groupme call
+    # @param fetch_all [Boolean] if true, fetches all messages for the group
+    def messages(group_id, options = {}, fetch_all = false)
+      if fetch_all
+        get_all_messages(group_id)
+      else
+        get_messages(group_id, options)
+      end
     end
 
     # Get number of messages for a group
@@ -37,5 +43,26 @@ module GroupMe
       get("/groups/#{group_id}/messages")['count']
     end
     alias_method :message_count, :messages_count
+
+    private
+
+    def get_all_messages(group_id)
+      messages = []
+      last_id = ''
+      loop do
+        selection = get_messages(group_id, :before_id => last_id)
+        break if selection.empty?
+
+        last_id = selection.last.id
+        messages << selection
+      end
+
+      messages
+    end
+
+    def get_messages(group_id, options = {})
+      results = get("/groups/#{group_id}/messages", options)
+      results.is_a?(Faraday::Response) ? [] : results.messages
+    end
   end
 end

--- a/lib/groupme/version.rb
+++ b/lib/groupme/version.rb
@@ -1,3 +1,3 @@
 module GroupMe
-  VERSION = '0.0.6'
+  VERSION = '0.0.6'.freeze
 end


### PR DESCRIPTION
The default messages call only returned the 20 most recent messages and didn't allow us to pass parameters that the groupme api would accept.

- I updated the get method in client to allow for query params to be passed to the groupme api
- I added a get_all_messages method that takes a group_id and returns all messages for that group
- I extended the messages method to allow options to be passed to the groupme #messages_index call

All changes should be backwards compatible.

Thanks for making this gem!